### PR TITLE
Update assert messages in SP800_76_Tests.java

### DIFF
--- a/conformancelib/src/main/java/gov/gsa/pivconformance/conformancelib/tests/SP800_76_Tests.java
+++ b/conformancelib/src/main/java/gov/gsa/pivconformance/conformancelib/tests/SP800_76_Tests.java
@@ -418,9 +418,9 @@ public class SP800_76_Tests {
 		int biometricDataBlockLength  = (((recordLength[0] & 0xFF) << 8) | (recordLength[1] & 0xFF));
 		
 		//BDB length must be between 26 and 1574
-        assertTrue(biometricDataBlockLength >= 26 && biometricDataBlockLength <= 1574, "Fingerprint recod length is not 26 <= L <= 1574");
-        //Confirm that the record length value is the same at the length of the leftover buffer
-        assertTrue(biometricDataBlockLength == biometricDataBlock.length, "Fingerprint recod length does not match leftover buffer length");
+        assertTrue(biometricDataBlockLength >= 26 && biometricDataBlockLength <= 1574, "Fingerprint record length is not 26 <= L <= 1574");
+        //Confirm that the record length value is the same as the length of the leftover buffer
+        assertTrue(biometricDataBlockLength == biometricDataBlock.length, "Fingerprint record length does not match leftover buffer length");
 	}
 	
 	


### PR DESCRIPTION
Fixed spelling of "record" in assert messages.

- Spelling error displaying in assertion logs
- Fixed spelling on lines: 421 and 423
- Fixed usage of `is` to `as` in the comments 

@SuGhadiali 
@rsherwood-gsa 
@JBPayne007 
